### PR TITLE
added imp and clks to the schema

### DIFF
--- a/tap_groundtruth/streams.py
+++ b/tap_groundtruth/streams.py
@@ -72,6 +72,8 @@ class CreativeStatsStream(GroundTruthStream):
         th.Property("advertiser_bid_type", th.StringType),
         th.Property("budget_type", th.StringType),
         th.Property("impressions", th.IntegerType),
+        th.Property("imp", th.IntegerType),
+        th.Property("clks", th.IntegerType),
         th.Property("clicks", th.IntegerType),
         th.Property("daily_reach", th.IntegerType),
         th.Property("ctr", th.NumberType),


### PR DESCRIPTION
## Description
Added the `imp` and `clks` to the schema for creative stats. The API docs show impressions and clicks but those don't actually output anything
